### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/schafweide/8e3c510e-7b0d-4e7e-bb35-f706f6d3dc6f/037a4fb0-15e9-4487-b693-abe2c58fd448/_apis/work/boardbadge/f2ac1272-cb66-4e74-ad0f-31a898d435b4)](https://dev.azure.com/schafweide/8e3c510e-7b0d-4e7e-bb35-f706f6d3dc6f/_boards/board/t/037a4fb0-15e9-4487-b693-abe2c58fd448/Microsoft.RequirementCategory)
 # hello-world
 Just another Hello to the World
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#9](https://dev.azure.com/schafweide/8e3c510e-7b0d-4e7e-bb35-f706f6d3dc6f/_workitems/edit/9). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.