### PR TITLE
Remove Azure Board Badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,6 @@
 # hello-world
 Just another Hello to the World
 
-# Azure Board Badge
-
- [![Board Status](https://dev.azure.com/schafweide/8e3c510e-7b0d-4e7e-bb35-f706f6d3dc6f/037a4fb0-15e9-4487-b693-abe2c58fd448/_apis/work/boardbadge/f2ac1272-cb66-4e74-ad0f-31a898d435b4?columnOptions=1)](https://dev.azure.com/schafweide/8e3c510e-7b0d-4e7e-bb35-f706f6d3dc6f/_boards/board/t/037a4fb0-15e9-4487-b693-abe2c58fd448/Issues/)
- 
  _______
 < Hello >
  -------


### PR DESCRIPTION
Removed Azure Board Badge section from README.
fixed dup of badge [[AB#10](https://dev.azure.com/schafweide/8e3c510e-7b0d-4e7e-bb35-f706f6d3dc6f/_workitems/edit/10)] [[[AB#10](https://dev.azure.com/schafweide/8e3c510e-7b0d-4e7e-bb35-f706f6d3dc6f/_workitems/edit/10)]] @andreas-bruns